### PR TITLE
Add multi-language preference support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export class YoutubeTranscriptNotAvailableError extends YoutubeTranscriptError {
 export class YoutubeTranscriptNotAvailableLanguageError extends YoutubeTranscriptError {
   constructor(lang: string, availableLangs: string[], videoId: string) {
     super(
-      `No transcripts are available in ${lang} this video (${videoId}). Available languages: ${availableLangs.join(
+      `No transcripts are available in ${lang} for this video (${videoId}). Available languages: ${availableLangs.join(
         ', '
       )}`
     );


### PR DESCRIPTION
This PR adds support for multiple languages in the TranscriptConfig, so that you can provide an ordered array of preferred languages in case the video has a few.
This also helps prevent YoutubeTranscriptNotAvailableLanguageError errors by allowing an array of optional languages in the TranscriptConfig.